### PR TITLE
feat(core): allow to duplicate inactive session

### DIFF
--- a/libs/core/src/lib/index.ts
+++ b/libs/core/src/lib/index.ts
@@ -8,3 +8,4 @@ export * from './navigatable-router.js';
 export * from './db.service.js';
 export * from './settings.service.js';
 export * from './wakelock.service.js';
+export * from './utils/index.js';

--- a/libs/core/src/lib/navigatable-router.ts
+++ b/libs/core/src/lib/navigatable-router.ts
@@ -2,12 +2,16 @@ import { Router } from '@lit-labs/router';
 
 export class NavigatableRouter extends Router {
   /**
-   * Similar to {@link Routes.goto()} but changes location history as well.
+   * Similar to {@link Router.goto()} but changes location history as well.
    *
    * Fixes bug in {@link Router} {@see https://github.com/lit/lit/discussions/3256}
    */
-  navigateTo(pathname: string) {
-    window.history.pushState(null, '', pathname);
+  navigateTo(pathname: string, state: unknown = null) {
+    window.history.pushState(state, '', pathname);
     return this.goto(pathname);
+  }
+
+  getState(): unknown {
+    return window.history.state;
   }
 }

--- a/libs/core/src/lib/player-stats/score-player-stats.ts
+++ b/libs/core/src/lib/player-stats/score-player-stats.ts
@@ -43,7 +43,7 @@ export class ScorePlayerStats implements PlayerStats, UpdatablePlayerStats {
 
   getScoreRestrictions(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    stats: ScorePlayerStatsData
+    stats: ScorePlayerStatsData,
   ): ScoreRestrictionsPlayerStats {
     return this.scoreRestrictions;
   }
@@ -52,4 +52,10 @@ export class ScorePlayerStats implements PlayerStats, UpdatablePlayerStats {
   getScoreLabel(stats: ScorePlayerStatsData): string {
     return 'Score';
   }
+}
+
+export function isScorePlayerStatsData(
+  stats: PlayerStatsData,
+): stats is ScorePlayerStatsData {
+  return 'scoreCount' in stats;
 }

--- a/libs/core/src/lib/routes.ts
+++ b/libs/core/src/lib/routes.ts
@@ -9,7 +9,7 @@ export function getRoutes(baseUrl = '/'): RouteConfig[] {
       enter: () => import('@game-companion/core/sessions').then(),
     },
     {
-      path: `${baseUrl}session/new`,
+      path: `${baseUrl}new-session*`,
       render: () => html`<gc-new-session></gc-new-session>`,
       enter: () => import('@game-companion/core/new-session').then(),
     },

--- a/libs/core/src/lib/utils/index.ts
+++ b/libs/core/src/lib/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './shallow-equals.js';

--- a/libs/core/src/lib/utils/shallow-equals.ts
+++ b/libs/core/src/lib/utils/shallow-equals.ts
@@ -1,0 +1,14 @@
+export function isShallowEqual(a: object, b: object): boolean {
+  if (a === b) {
+    return true;
+  }
+
+  const aKeys = Object.keys(a) as never[];
+  const bKeys = Object.keys(b) as never[];
+
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+
+  return aKeys.every((key) => a[key] === b[key]);
+}

--- a/libs/core/src/player/player.element.ts
+++ b/libs/core/src/player/player.element.ts
@@ -75,7 +75,7 @@ export class GcPlayerElement extends LitElement {
   @state() private declare currentPlayerStats?: PlayerStatsData;
 
   @webContextConsumer(NavigatableRouter)
-  private router?: NavigatableRouter;
+  private declare router: NavigatableRouter;
 
   @webContextConsumer(PlayerStatsRegistry)
   private declare playerStatsRegistry: PlayerStatsRegistry;
@@ -126,16 +126,19 @@ export class GcPlayerElement extends LitElement {
           aria-label="Next player"
           @click=${this.nextPlayer}
         ></mdc-icon-button>
-        <mdc-icon-button
-          slot="toolbar"
-          type="button"
-          icon="add_circle"
-          title="Add Player Stats"
-          aria-label="Add Player Stats"
-          @click=${{
-            handleEvent: () => this.#playerStatsDialogRef.value?.open(),
-          }}
-        ></mdc-icon-button>
+        ${when(
+          this.session?.isActive,
+          () => html`<mdc-icon-button
+            slot="toolbar"
+            type="button"
+            icon="add_circle"
+            title="Add Player Stats"
+            aria-label="Add Player Stats"
+            @click=${{
+              handleEvent: () => this.#playerStatsDialogRef.value?.open(),
+            }}
+          ></mdc-icon-button>`,
+        )}
         <div class="mdc-layout-grid">
           <div class="mdc-layout-grid__inner">
             ${when(
@@ -189,18 +192,21 @@ export class GcPlayerElement extends LitElement {
             >
               <div>${this.getPlayerStatsName(ps)}</div>
               <div>${this.renderPlayerStats(ps)}</div>
-              <mdc-button
-                slot="actions"
-                type="button"
-                icon="delete"
-                outlined
-                ?disabled=${this.isRemovingPlayerStats}
-                @click=${{
-                  handleEvent: () => this.confirmRemovePlayerStats(ps),
-                }}
-              >
-                Remove Stats
-              </mdc-button>
+              ${when(
+                this.session?.isActive,
+                () => html`<mdc-button
+                  slot="actions"
+                  type="button"
+                  icon="delete"
+                  outlined
+                  ?disabled=${this.isRemovingPlayerStats}
+                  @click=${{
+                    handleEvent: () => this.confirmRemovePlayerStats(ps),
+                  }}
+                >
+                  Remove Stats
+                </mdc-button>`,
+              )}
             </mdc-card>
           </div>`,
         )}`,
@@ -208,19 +214,22 @@ export class GcPlayerElement extends LitElement {
         class="mdc-layout-grid__cell mdc-layout-grid__cell--span-6"
       >
         <h3>Player has no stats!</h3>
-        <mdc-button
-          type="link"
-          href="#"
-          @click=${{
-            handleEvent: (e: Event) => {
-              e.preventDefault();
-              this.#playerStatsDialogRef.value?.open();
-            },
-          }}
-        >
-          Add Player Stats
-        </mdc-button>
-        to start tracking score.
+        ${when(
+          this.session?.isActive,
+          () => html`<mdc-button
+              type="link"
+              href="#"
+              @click=${{
+                handleEvent: (e: Event) => {
+                  e.preventDefault();
+                  this.#playerStatsDialogRef.value?.open();
+                },
+              }}
+            >
+              Add Player Stats
+            </mdc-button>
+            to start tracking score.`,
+        )}
       </div>`,
     )}`;
   }
@@ -232,7 +241,7 @@ export class GcPlayerElement extends LitElement {
       return;
     }
 
-    if (isUpdatablePlayerStats(playerStats)) {
+    if (isUpdatablePlayerStats(playerStats) && this.session?.isActive) {
       return playerStats.renderUpdateStats(data);
     } else {
       return playerStats.renderStats(data);
@@ -446,7 +455,7 @@ export class GcPlayerElement extends LitElement {
       return;
     }
 
-    this.router?.navigateTo(
+    this.router.navigateTo(
       `/session/${this.session.id}/player/${nextPlayer.id}`,
     );
   }

--- a/libs/core/src/session/session.element.ts
+++ b/libs/core/src/session/session.element.ts
@@ -1,22 +1,23 @@
 import { webContextConsumer } from '@game-companion/context';
 import type { Session } from '@game-companion/core';
 import {
-  isNameablePlayerStats,
-  isUpdatablePlayerStats,
+  NavigatableRouter,
   Player,
   PlayerStatsData,
   PlayerStatsRegistry,
   SessionsService,
   UpdatePlayerStatsDataEvent,
   WakelockService,
+  isNameablePlayerStats,
+  isUpdatablePlayerStats,
 } from '@game-companion/core';
 import {
+  LitElement,
+  PropertyValueMap,
   css,
   customElement,
   html,
-  LitElement,
   property,
-  PropertyValueMap,
   repeat,
   state,
   when,
@@ -71,6 +72,9 @@ export class GcSessionElement extends LitElement {
   @webContextConsumer(WakelockService)
   private declare wakelockService: WakelockService;
 
+  @webContextConsumer(NavigatableRouter)
+  private declare router: NavigatableRouter;
+
   constructor() {
     super();
 
@@ -119,6 +123,17 @@ export class GcSessionElement extends LitElement {
               @click=${this.finishSession}
             ></mdc-icon-button>
           `,
+        () => html`
+          <mdc-icon-button
+            slot="toolbar"
+            type="button"
+            class="mdc-top-app-bar__navigation-icon"
+            icon="content_copy"
+            title="Duplicate session"
+            aria-label="Duplicate session"
+            @click=${this.duplicateSession}
+          ></mdc-icon-button>
+        `,
       )}
       <div class="mdc-layout-grid">
         <div class="mdc-layout-grid__inner">
@@ -353,5 +368,15 @@ export class GcSessionElement extends LitElement {
         hasDismiss: true,
       });
     }
+  }
+
+  private async duplicateSession() {
+    if (!this.session) {
+      return;
+    }
+
+    await this.router.navigateTo(
+      `/new-session?duplicateSession=${this.session.id}`,
+    );
   }
 }

--- a/libs/core/src/sessions/sessions.element.ts
+++ b/libs/core/src/sessions/sessions.element.ts
@@ -110,7 +110,7 @@ export class GcSessionsElement extends LitElement {
       </mdc-top-app-bar>
       <mdc-fab
         type="link"
-        href="/session/new"
+        href="/new-session"
         icon="group_add"
         title="Create new session"
         aria-label="Create new session"


### PR DESCRIPTION
When a session has ended there is now an option to duplicate session which will bring user to a "New Session" screen with the same players and their global stats from the duplicated session.
Any edits can be done at this stage as usual when creating a new sessions.
